### PR TITLE
Add JumpItem.FlagsToEnable

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ComGuids.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ComGuids.cs
@@ -33,6 +33,8 @@ namespace MS.Internal.AppModel
         public const string ShellFolder = "000214E6-0000-0000-C000-000000000046";
         /// <summary>IID_IShellLink</summary>
         public const string ShellLink = "000214F9-0000-0000-C000-000000000046";
+        /// <summary>IID_IShellLinkDataList</summary>
+        public const string ShellLinkDataList = "45E2B4AE-B1C3-11D0-B92F-00A0C90312E1";
         /// <summary>IID_IShellItem</summary>
         public const string ShellItem = "43826d1e-e718-42ee-bc55-a1e261c37bfe";
         /// <summary>IID_IShellItem2</summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ShellProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ShellProvider.cs
@@ -384,16 +384,27 @@ namespace MS.Internal.AppModel
         InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown),
         Guid(IID.ShellLinkDataList),
     ]
+<<<<<<< HEAD
     internal interface IShellLinkDataList
+=======
+    internal interface IShellLinkDataListW
+>>>>>>> b99fc6ea... Add FlagsToEnable property to JumpTask to allow JumpList to set the SHELL_LINK_DATA_FLAGS enumeration on the shell link. This enables various scenarios such as e.g. being able to request elevation of a JumpTask.
     {
         [PreserveSig]
         Int32 AddDataBlock(IntPtr pDataBlock);
 
         [PreserveSig]
+<<<<<<< HEAD
         Int32 CopyDataBlock(uint dwSig, out IntPtr ppDataBlock);
 
         [PreserveSig]
         Int32 RemoveDataBlock(uint dwSig);
+=======
+        Int32 CopyDataBlock(UInt32 dwSig, out IntPtr ppDataBlock);
+
+        [PreserveSig]
+        Int32 RemoveDataBlock(UInt32 dwSig);
+>>>>>>> b99fc6ea... Add FlagsToEnable property to JumpTask to allow JumpList to set the SHELL_LINK_DATA_FLAGS enumeration on the shell link. This enables various scenarios such as e.g. being able to request elevation of a JumpTask.
 
         void GetFlags(out uint pdwFlags);
         void SetFlags(uint dwFlags);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ShellProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ShellProvider.cs
@@ -384,27 +384,16 @@ namespace MS.Internal.AppModel
         InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown),
         Guid(IID.ShellLinkDataList),
     ]
-<<<<<<< HEAD
     internal interface IShellLinkDataList
-=======
-    internal interface IShellLinkDataListW
->>>>>>> b99fc6ea... Add FlagsToEnable property to JumpTask to allow JumpList to set the SHELL_LINK_DATA_FLAGS enumeration on the shell link. This enables various scenarios such as e.g. being able to request elevation of a JumpTask.
     {
         [PreserveSig]
         Int32 AddDataBlock(IntPtr pDataBlock);
 
         [PreserveSig]
-<<<<<<< HEAD
         Int32 CopyDataBlock(uint dwSig, out IntPtr ppDataBlock);
 
         [PreserveSig]
         Int32 RemoveDataBlock(uint dwSig);
-=======
-        Int32 CopyDataBlock(UInt32 dwSig, out IntPtr ppDataBlock);
-
-        [PreserveSig]
-        Int32 RemoveDataBlock(UInt32 dwSig);
->>>>>>> b99fc6ea... Add FlagsToEnable property to JumpTask to allow JumpList to set the SHELL_LINK_DATA_FLAGS enumeration on the shell link. This enables various scenarios such as e.g. being able to request elevation of a JumpTask.
 
         void GetFlags(out uint pdwFlags);
         void SetFlags(uint dwFlags);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ShellProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ShellProvider.cs
@@ -384,7 +384,7 @@ namespace MS.Internal.AppModel
         InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown),
         Guid(IID.ShellLinkDataList),
     ]
-    internal interface IShellLinkDataListW
+    internal interface IShellLinkDataList
     {
         [PreserveSig]
         Int32 AddDataBlock(IntPtr pDataBlock);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ShellProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ShellProvider.cs
@@ -381,6 +381,30 @@ namespace MS.Internal.AppModel
 
     [
         ComImport,
+        InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown),
+        Guid(IID.ShellLinkDataList),
+    ]
+    internal interface IShellLinkDataListW
+    {
+        [PreserveSig]
+        Int32 AddDataBlock(IntPtr pDataBlock);
+
+        [PreserveSig]
+        Int32 CopyDataBlock(uint dwSig, out IntPtr ppDataBlock);
+
+        [PreserveSig]
+        Int32 RemoveDataBlock(uint dwSig);
+
+        void GetFlags(out uint pdwFlags);
+        void SetFlags(uint dwFlags);
+    }
+
+    /// <SecurityNote>
+    /// Critical: Suppresses unmanaged code security.
+    /// </SecurityNote>
+    [SecurityCritical(SecurityCriticalScope.Everything), SuppressUnmanagedCodeSecurity]
+    [
+        ComImport,
         InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
         Guid(IID.FileDialogEvents),
     ]

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
@@ -952,15 +952,17 @@ namespace System.Windows.Shell
                     link.SetDescription(jumpTask.Description);
                 }
 
-		if (jumpTask.FlagsToEnable != null)
-		{
-			var shellLinkDataList = (ShellLinkDataList)link;
-			shellLinkDataList.GetFlags(out UInt32 flags);
-			foreach (var flagToEnable in jumpTask.FlagsToEnable)
-			{
-				flags |= flagToEnable;
-			}
-			shellLinkDataList.SetFlags(flags);
+                if (jumpTask.FlagsToEnable != null)
+                {
+                    var shellLinkDataList = (ShellLinkDataList)link;
+                    shellLinkDataList.GetFlags(out UInt32 flags);
+                    foreach (var flagToEnable in jumpTask.FlagsToEnable)
+                    {
+                        flags |= flagToEnable;
+                    }
+
+                    shellLinkDataList.SetFlags(flags);
+                }
 
                 IPropertyStore propStore = (IPropertyStore)link;
                 var pv = new PROPVARIANT();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
@@ -958,7 +958,7 @@ namespace System.Windows.Shell
                     shellLinkDataList.GetFlags(out UInt32 flags);
                     foreach (var flagToEnable in jumpTask.FlagsToEnable)
                     {
-                        flags |= flagToEnable;
+                        flags |= (uint)flagToEnable;
                     }
 
                     shellLinkDataList.SetFlags(flags);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
@@ -961,7 +961,6 @@ namespace System.Windows.Shell
 				flags |= flagToEnable;
 			}
 			shellLinkDataList.SetFlags(flags);
-		}
 
                 IPropertyStore propStore = (IPropertyStore)link;
                 var pv = new PROPVARIANT();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
@@ -952,6 +952,17 @@ namespace System.Windows.Shell
                     link.SetDescription(jumpTask.Description);
                 }
 
+		if (jumpTask.FlagsToEnable != null)
+		{
+			var shellLinkDataList = (ShellLinkDataList)link;
+			shellLinkDataList.GetFlags(out UInt32 flags);
+			foreach (var flagToEnable in jumpTask.FlagsToEnable)
+			{
+				flags |= flagToEnable;
+			}
+			shellLinkDataList.SetFlags(flags);
+		}
+
                 IPropertyStore propStore = (IPropertyStore)link;
                 var pv = new PROPVARIANT();
                 try

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
@@ -954,7 +954,7 @@ namespace System.Windows.Shell
 
                 if (jumpTask.FlagsToEnable != null)
                 {
-                    var shellLinkDataList = (ShellLinkDataList)link;
+                    var shellLinkDataList = (IShellLinkDataList)link;
                     shellLinkDataList.GetFlags(out UInt32 flags);
                     foreach (var flagToEnable in jumpTask.FlagsToEnable)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-﻿
+using System.Collections;
 
 namespace System.Windows.Shell
 {
@@ -29,6 +29,10 @@ namespace System.Windows.Shell
         /// Shell link data flags to enable. For more details see the SHELL_LINK_DATA_FLAGS documentation
         /// https://docs.microsoft.com/windows/desktop/api/shlobj_core/ne-shlobj_core-shell_link_data_flags 
         /// </summary>
+<<<<<<< HEAD
         public int[] FlagsToEnable { get; set; }
+=======
+        public IEnumerable<UInt32> FlagsToEnable { get; set; }
+>>>>>>> b99fc6ea... Add FlagsToEnable property to JumpTask to allow JumpList to set the SHELL_LINK_DATA_FLAGS enumeration on the shell link. This enables various scenarios such as e.g. being able to request elevation of a JumpTask.
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
@@ -29,6 +29,6 @@ namespace System.Windows.Shell
         /// Shell link data flags to enable. For more details see the SHELL_LINK_DATA_FLAGS documentation
         /// https://docs.microsoft.com/windows/desktop/api/shlobj_core/ne-shlobj_core-shell_link_data_flags 
         /// </summary>
-        public uint[] FlagsToEnable { get; set; }
+        public int[] FlagsToEnable { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
@@ -29,6 +29,6 @@ namespace System.Windows.Shell
         /// Shell link data flags to enable. For more details see the SHELL_LINK_DATA_FLAGS documentation
         /// https://docs.microsoft.com/windows/desktop/api/shlobj_core/ne-shlobj_core-shell_link_data_flags 
         /// </summary>
-        public UInt32[] FlagsToEnable { get; set; }
+        public int[] FlagsToEnable { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
@@ -29,6 +29,6 @@ namespace System.Windows.Shell
         /// Shell link data flags to enable. For more details see the SHELL_LINK_DATA_FLAGS documentation
         /// https://docs.microsoft.com/windows/desktop/api/shlobj_core/ne-shlobj_core-shell_link_data_flags 
         /// </summary>
-        public int[] FlagsToEnable { get; set; }
+        public uint[] FlagsToEnable { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
@@ -29,10 +29,6 @@ namespace System.Windows.Shell
         /// Shell link data flags to enable. For more details see the SHELL_LINK_DATA_FLAGS documentation
         /// https://docs.microsoft.com/windows/desktop/api/shlobj_core/ne-shlobj_core-shell_link_data_flags 
         /// </summary>
-<<<<<<< HEAD
         public int[] FlagsToEnable { get; set; }
-=======
-        public IEnumerable<UInt32> FlagsToEnable { get; set; }
->>>>>>> b99fc6ea... Add FlagsToEnable property to JumpTask to allow JumpList to set the SHELL_LINK_DATA_FLAGS enumeration on the shell link. This enables various scenarios such as e.g. being able to request elevation of a JumpTask.
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
@@ -24,5 +24,11 @@ namespace System.Windows.Shell
         public string IconResourcePath { get; set; }
 
         public int IconResourceIndex { get; set; }
+
+        /// <summary>
+        /// Shell link data flags to enable. For more details see the SHELL_LINK_DATA_FLAGS documentation
+        /// https://docs.microsoft.com/windows/desktop/api/shlobj_core/ne-shlobj_core-shell_link_data_flags 
+        /// </summary>
+        public UInt32[] FlagsToEnable { get; set; }
     }
 }


### PR DESCRIPTION
The value for these flags comes from [`SHELL_LINK_DATA_FLAGS`](https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/ne-shlobj_core-shell_link_data_flags). This allows for, inter alia, the ability to request that a JumpTask be run elevated.