### PR TITLE
Define Value property of Setter as XAML content property

### DIFF
--- a/src/Microsoft.DotNet.Wpf/ApiCompat/Baselines/PresentationFramework-ref-Net48.baseline.txt
+++ b/src/Microsoft.DotNet.Wpf/ApiCompat/Baselines/PresentationFramework-ref-Net48.baseline.txt
@@ -24,4 +24,5 @@ TypesMustExist : Type 'System.Windows.Interop.DocObjHost' does not exist in the 
 CannotRemoveAttribute : Attribute 'System.ComponentModel.TypeConverterAttribute' exists on 'System.Windows.Markup.StaticExtension' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.TypeConverterAttribute' exists on 'System.Windows.Markup.TypeExtension' in the contract but not the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Windows.Markup.XamlParseException' does not implement interface 'System.Runtime.InteropServices._Exception' in the implementation but it does in the contract.
-Total Issues: 25
+CannotRemoveAttribute : Attribute 'System.Windows.Markup.ContentPropertyAttribute' exists on 'System.Windows.Setter' in the contract but not the implementation.
+Total Issues: 26

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Setter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Setter.cs
@@ -24,6 +24,7 @@ namespace System.Windows
     /// </summary>
     [XamlSetMarkupExtensionAttribute("ReceiveMarkupExtension")]
     [XamlSetTypeConverterAttribute("ReceiveTypeConverter")] 
+    [ContentProperty("Value")]
     public class Setter : SetterBase, ISupportInitialize
     {
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -1123,6 +1123,7 @@ namespace System.Windows
     public delegate void SessionEndingCancelEventHandler(object sender, System.Windows.SessionEndingCancelEventArgs e);
     [System.Windows.Markup.XamlSetMarkupExtensionAttribute("ReceiveMarkupExtension")]
     [System.Windows.Markup.XamlSetTypeConverterAttribute("ReceiveTypeConverter")]
+    [System.Windows.Markup.ContentPropertyAttribute("Value")]
     public partial class Setter : System.Windows.SetterBase, System.ComponentModel.ISupportInitialize
     {
         public Setter() { }


### PR DESCRIPTION
This PR (finally!) lets us omit the `<Setter.Value> ... </Setter.Value>` boilerplate around every control template we write.