### PR TITLE
Do not echo output from dotnet-install.ps1

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -252,7 +252,7 @@ function InstallDotNet([string] $dotnetRoot,
   if ($noPath) { $installParameters.NoPath = $True }
 
   try {
-    & $installScript @installParameters
+    & $installScript @installParameters 6> $null
   }
   catch {
     if ($runtimeSourceFeed -or $runtimeSourceFeedKey) {
@@ -266,7 +266,7 @@ function InstallDotNet([string] $dotnetRoot,
       }
 
       try {
-        & $installScript @installParameters
+        & $installScript @installParameters 6> $null
       }
       catch {
         Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Failed to install dotnet from custom location '$runtimeSourceFeed'."


### PR DESCRIPTION
This script is hardcoded to print a four-line admonishment about the existence of the .NET platform installers when it is called.

Every. Damn. Time.

**No more!**