### PR TITLE
Fix serious build incrementality issues

### DIFF
--- a/eng/WpfArcadeSdk/tools/ExtendedAssemblyInfo.targets
+++ b/eng/WpfArcadeSdk/tools/ExtendedAssemblyInfo.targets
@@ -341,7 +341,7 @@ using System.Runtime.Versioning;
     <Delete Condition="Exists('$(GeneratedExtendedAssemblyInfoFile)')" Files="$(GeneratedExtendedAssemblyInfoFile)" />
     <WriteLinesToFile Lines="@(ExtendedAssemblyInfoFileContent->'%(Text)')"
                       File="$(GeneratedExtendedAssemblyInfoFile)"
-                      Overwrite="true" />
+                      Overwrite="true" WriteOnlyWhenDifferent="true" />
 
     <ItemGroup>
       <Compile Include="$(GeneratedExtendedAssemblyInfoFile)" />

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
@@ -187,7 +187,7 @@ END
 
     <WriteLinesToFile Lines="@(_ExtendenNativeVersionFileLines)"
                       File="$(NativeResourceFileWithVersionInformation)"
-                      Overwrite="true" />
+                      Overwrite="true" WriteOnlyWhenDifferent="true" />
 
     <ItemGroup>
       <ResourceCompile Remove="$(NativeResourceFileWithVersionInformation)" />
@@ -267,7 +267,7 @@ using namespace System::Runtime::Versioning;
 
     <WriteLinesToFile Lines="@(AssemblyInfoFile->'%(Text)')"
                       File="$(TargetFrameworkMonikerAssemblyAttributesPath)"
-                      Overwrite="true" />
+                      Overwrite="true" WriteOnlyWhenDifferent="true" />
     <ItemGroup>
       <ClCompile Include="$(TargetFrameworkMonikerAssemblyAttributesPath)">
         <!-- The appropriate CompileAsManaged setting will automatically be set depending on the current CLRSupport value -->
@@ -386,8 +386,7 @@ using namespace System::Runtime::Versioning;
     <Delete Files="$(CppCliHelperProject)" Condition="Exists('$(CppCliHelperProject)')" />
 
     <WriteLinesToFile Lines="%(CppClrSupportProject.Text)"
-                      File="$(CppCliHelperProject)"
-                      Overwrite="false"/>
+                      Overwrite="false" WriteOnlyWhenDifferent="true" />
 
     <!--
     Do not build - just ask ResolveReferences + IdentifyNetCoreReferences for the information
@@ -541,7 +540,7 @@ using namespace System::Runtime::Versioning;
 
     <WriteLinesToFile Lines="%(CppSupportProject.Text)"
                       File="$(CppHelperProject)"
-                      Overwrite="false"/>
+                      Overwrite="false" WriteOnlyWhenDifferent="true" />
 
     <!--
     Do not build - just ask IdentifyNetCoreReferences for the information


### PR DESCRIPTION
MSBuild marked `WpfGfx.dll` and all its dependencies for a full rebuild every time because various `<WriteLinesToFile>` calls lacked `WriteOnlyWhenDifferent=true`. These changes make incremental builds (i.e. when an older build exists on disk) significantly faster.